### PR TITLE
Copy attributes instead of using passed in values

### DIFF
--- a/CenterAlignedCollectionViewFlowLayout.swift
+++ b/CenterAlignedCollectionViewFlowLayout.swift
@@ -14,11 +14,8 @@ public class CenterAlignedCollectionViewFlowLayout: UICollectionViewFlowLayout {
       return nil
     }
     
-    var attributes = [UICollectionViewLayoutAttributes]()
-    for attr in oldAttributes{
-      if let attribute = attr.copy() as? UICollectionViewLayoutAttributes{
-          attributes.append(attribute)
-      }
+    let attributes: [UICollectionViewLayoutAttributes] = oldAttributes.flatMap {
+        $0.copy() as? UICollectionViewLayoutAttributes
     }
 
     

--- a/CenterAlignedCollectionViewFlowLayout.swift
+++ b/CenterAlignedCollectionViewFlowLayout.swift
@@ -13,11 +13,7 @@ public class CenterAlignedCollectionViewFlowLayout: UICollectionViewFlowLayout {
     guard let oldAttributes = super.layoutAttributesForElementsInRect(rect) else {
       return nil
     }
-    
-    let attributes: [UICollectionViewLayoutAttributes] = oldAttributes.flatMap {
-        $0.copy() as? UICollectionViewLayoutAttributes
-    }
-
+    let attributes = oldAttributes.map { $0.copy() as! UICollectionViewLayoutAttributes }
     
     // We will do centering alignment only on the Cell layout attributes
     let cellAttributes = attributes.filter({ (layout: UICollectionViewLayoutAttributes) -> Bool in

--- a/CenterAlignedCollectionViewFlowLayout.swift
+++ b/CenterAlignedCollectionViewFlowLayout.swift
@@ -10,9 +10,17 @@ import UIKit
 
 public class CenterAlignedCollectionViewFlowLayout: UICollectionViewFlowLayout {
   public override func layoutAttributesForElementsInRect(rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
-    guard let attributes = super.layoutAttributesForElementsInRect(rect) else {
+    guard let oldAttributes = super.layoutAttributesForElementsInRect(rect) else {
       return nil
     }
+    
+    var attributes = [UICollectionViewLayoutAttributes]()
+    for attr in oldAttributes{
+      if let attribute = attr.copy() as? UICollectionViewLayoutAttributes{
+          attributes.append(attribute)
+      }
+    }
+
     
     // We will do centering alignment only on the Cell layout attributes
     let cellAttributes = attributes.filter({ (layout: UICollectionViewLayoutAttributes) -> Bool in


### PR DESCRIPTION
This fixes an issue where not copying attributes will have the compiler give out when moving cells to different index paths
